### PR TITLE
Implement RESTful hardware API endpoints

### DIFF
--- a/app/api/hardware/alerts/[id]/route.ts
+++ b/app/api/hardware/alerts/[id]/route.ts
@@ -1,0 +1,191 @@
+import { createClient } from "@/lib/supabase/server"
+import { type NextRequest, NextResponse } from "next/server"
+
+export const dynamic = "force-dynamic"
+
+const ALERT_SELECT = `
+  *,
+  waste_events (
+    location_id,
+    location_name,
+    event_type,
+    coordinates
+  )
+`
+
+const ALERT_STATUSES = ["pending", "sent", "failed", "acknowledged"] as const
+
+type AlertStatus = (typeof ALERT_STATUSES)[number]
+
+type AlertUpdatePayload = {
+  status?: AlertStatus
+  alert_type?: string
+  message?: string
+  sent_at?: string
+  metadata?: Record<string, unknown> | null
+  acknowledged_by?: string
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value)
+}
+
+// GET /api/hardware/alerts/{id} - 获取警报详情
+export async function GET(_request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const supabase = await createClient()
+
+    const { data: alert, error } = await supabase
+      .from("alerts")
+      .select(ALERT_SELECT)
+      .eq("id", params.id)
+      .single()
+
+    if (error) {
+      if (error.code === "PGRST116") {
+        return NextResponse.json({ error: "未找到警报" }, { status: 404 })
+      }
+
+      console.error("查询警报详情失败:", error)
+      return NextResponse.json({ error: "查询警报详情失败" }, { status: 500 })
+    }
+
+    return NextResponse.json({
+      success: true,
+      data: alert,
+    })
+  } catch (error) {
+    console.error("API错误:", error)
+    return NextResponse.json({ error: "服务器内部错误" }, { status: 500 })
+  }
+}
+
+// PATCH /api/hardware/alerts/{id} - 更新警报信息 / 确认警报
+export async function PATCH(request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    let parsedBody: unknown
+
+    try {
+      parsedBody = await request.json()
+    } catch {
+      return NextResponse.json({ error: "请求体必须为JSON格式" }, { status: 400 })
+    }
+
+    if (!parsedBody || typeof parsedBody !== "object" || Array.isArray(parsedBody)) {
+      return NextResponse.json({ error: "请求体格式不正确" }, { status: 400 })
+    }
+
+    const body = parsedBody as AlertUpdatePayload
+
+    if (!body.status && !body.alert_type && !body.message && body.metadata === undefined && !body.sent_at) {
+      return NextResponse.json({ error: "请提供需要更新的字段" }, { status: 400 })
+    }
+
+    const supabase = await createClient()
+
+    const { data: existingAlert, error: fetchError } = await supabase
+      .from("alerts")
+      .select("metadata")
+      .eq("id", params.id)
+      .single()
+
+    if (fetchError) {
+      if (fetchError.code === "PGRST116") {
+        return NextResponse.json({ error: "未找到警报" }, { status: 404 })
+      }
+
+      console.error("查询警报失败:", fetchError)
+      return NextResponse.json({ error: "查询警报失败" }, { status: 500 })
+    }
+
+    const updates: Record<string, unknown> = {}
+    let metadata = existingAlert?.metadata as Record<string, unknown> | null
+    let metadataChanged = false
+
+    if (body.status) {
+      if (!ALERT_STATUSES.includes(body.status)) {
+        return NextResponse.json({ error: "警报状态无效" }, { status: 400 })
+      }
+
+      updates.status = body.status
+    }
+
+    if (body.alert_type !== undefined) {
+      if (typeof body.alert_type !== "string") {
+        return NextResponse.json({ error: "alert_type 必须为字符串" }, { status: 400 })
+      }
+      updates.alert_type = body.alert_type
+    }
+
+    if (body.message !== undefined) {
+      if (typeof body.message !== "string") {
+        return NextResponse.json({ error: "message 必须为字符串" }, { status: 400 })
+      }
+      updates.message = body.message
+    }
+
+    if (body.sent_at) {
+      const sentAt = Date.parse(body.sent_at)
+      if (Number.isNaN(sentAt)) {
+        return NextResponse.json({ error: "sent_at 时间格式无效" }, { status: 400 })
+      }
+      updates.sent_at = new Date(sentAt).toISOString()
+    }
+
+    if (body.metadata !== undefined) {
+      if (body.metadata === null) {
+        metadata = null
+      } else if (!isRecord(body.metadata)) {
+        return NextResponse.json({ error: "metadata 必须为对象" }, { status: 400 })
+      } else {
+        metadata = {
+          ...(metadata ?? {}),
+          ...body.metadata,
+        }
+      }
+      metadataChanged = true
+    }
+
+    if (body.status === "acknowledged") {
+      const acknowledgedBy =
+        typeof body.acknowledged_by === "string" && body.acknowledged_by.trim().length > 0
+          ? body.acknowledged_by
+          : request.headers.get("x-device-id") || "edge_device"
+      metadata = {
+        ...(metadata ?? {}),
+        acknowledged_at: new Date().toISOString(),
+        acknowledged_by: acknowledgedBy,
+      }
+      metadataChanged = true
+    }
+
+    if (metadataChanged) {
+      updates.metadata = metadata
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return NextResponse.json({ error: "没有可更新的字段" }, { status: 400 })
+    }
+
+    const { data: alert, error: updateError } = await supabase
+      .from("alerts")
+      .update(updates)
+      .eq("id", params.id)
+      .select(ALERT_SELECT)
+      .single()
+
+    if (updateError) {
+      console.error("更新警报失败:", updateError)
+      return NextResponse.json({ error: "更新警报失败" }, { status: 500 })
+    }
+
+    return NextResponse.json({
+      success: true,
+      message: "警报已更新",
+      data: alert,
+    })
+  } catch (error) {
+    console.error("API错误:", error)
+    return NextResponse.json({ error: "服务器内部错误" }, { status: 500 })
+  }
+}

--- a/app/api/hardware/alerts/route.ts
+++ b/app/api/hardware/alerts/route.ts
@@ -1,6 +1,18 @@
 import { createClient } from "@/lib/supabase/server"
 import { type NextRequest, NextResponse } from "next/server"
 
+export const dynamic = "force-dynamic"
+
+const ALERT_SELECT = `
+  *,
+  waste_events (
+    location_id,
+    location_name,
+    event_type,
+    coordinates
+  )
+`
+
 // GET /api/hardware/alerts - 获取警报列表
 export async function GET(request: NextRequest) {
   try {
@@ -8,23 +20,14 @@ export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url)
 
     const location_id = searchParams.get("location_id")
-    const status = searchParams.get("status") || "active"
+    const status = searchParams.get("status")
     const limit = Number.parseInt(searchParams.get("limit") || "20")
 
-    let query = supabase
-      .from("alerts")
-      .select(`
-        *,
-        waste_events (
-          location_id,
-          location_name,
-          event_type,
-          coordinates
-        )
-      `)
-      .eq("status", status)
-      .order("sent_at", { ascending: false })
-      .limit(limit)
+    let query = supabase.from("alerts").select(ALERT_SELECT).order("sent_at", { ascending: false }).limit(limit)
+
+    if (status) {
+      query = query.eq("status", status)
+    }
 
     if (location_id) {
       query = query.eq("waste_events.location_id", location_id)
@@ -33,6 +36,7 @@ export async function GET(request: NextRequest) {
     const { data: alerts, error } = await query
 
     if (error) {
+      console.error("查询警报失败:", error)
       return NextResponse.json({ error: "查询警报失败" }, { status: 500 })
     }
 
@@ -40,40 +44,6 @@ export async function GET(request: NextRequest) {
       success: true,
       data: alerts,
       count: alerts.length,
-    })
-  } catch (error) {
-    console.error("API错误:", error)
-    return NextResponse.json({ error: "服务器内部错误" }, { status: 500 })
-  }
-}
-
-// PUT /api/hardware/alerts/[id]/acknowledge - 确认警报
-export async function PUT(request: NextRequest, { params }: { params: { id: string } }) {
-  try {
-    const supabase = await createClient()
-    const { id } = params
-
-    const { data: alert, error } = await supabase
-      .from("alerts")
-      .update({
-        status: "acknowledged",
-        metadata: {
-          acknowledged_at: new Date().toISOString(),
-          acknowledged_by: "hardware_device",
-        },
-      })
-      .eq("id", id)
-      .select()
-      .single()
-
-    if (error) {
-      return NextResponse.json({ error: "确认警报失败" }, { status: 500 })
-    }
-
-    return NextResponse.json({
-      success: true,
-      message: "警报已确认",
-      data: alert,
     })
   } catch (error) {
     console.error("API错误:", error)

--- a/app/api/hardware/events/[id]/route.ts
+++ b/app/api/hardware/events/[id]/route.ts
@@ -1,16 +1,68 @@
 import { createClient } from "@/lib/supabase/server"
 import { type NextRequest, NextResponse } from "next/server"
 
-// GET /api/hardware/events/[id] - 获取特定事件详情
-export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
+export const dynamic = "force-dynamic"
+
+const EVENT_SELECT = `
+  *,
+  alerts (
+    id,
+    alert_type,
+    status,
+    sent_at
+  )
+`
+
+const EVENT_STATUSES = ["active", "investigating", "resolved", "false_positive"] as const
+
+type EventStatus = (typeof EVENT_STATUSES)[number]
+
+type Coordinates = {
+  lat: number
+  lng: number
+}
+
+type EventUpdatePayload = {
+  status?: EventStatus
+  confidence_score?: number
+  image_url?: string | null
+  video_url?: string | null
+  metadata?: Record<string, unknown> | null
+  resolved_at?: string | null
+  coordinates?: Coordinates | null
+}
+
+function isCoordinates(value: unknown): value is Coordinates {
+  if (!value || typeof value !== "object") {
+    return false
+  }
+
+  const { lat, lng } = value as { lat?: unknown; lng?: unknown }
+  return typeof lat === "number" && typeof lng === "number"
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value)
+}
+
+// GET /api/hardware/events/{id} - 获取事件详情
+export async function GET(_request: NextRequest, { params }: { params: { id: string } }) {
   try {
     const supabase = await createClient()
-    const { id } = params
 
-    const { data: event, error } = await supabase.from("waste_events").select("*").eq("id", id).single()
+    const { data: event, error } = await supabase
+      .from("waste_events")
+      .select(EVENT_SELECT)
+      .eq("id", params.id)
+      .single()
 
-    if (error || !event) {
-      return NextResponse.json({ error: "事件不存在" }, { status: 404 })
+    if (error) {
+      if (error.code === "PGRST116") {
+        return NextResponse.json({ error: "未找到事件" }, { status: 404 })
+      }
+
+      console.error("查询事件失败:", error)
+      return NextResponse.json({ error: "查询事件失败" }, { status: 500 })
     }
 
     return NextResponse.json({
@@ -23,39 +75,146 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
   }
 }
 
-// PUT /api/hardware/events/[id] - 更新事件状态
+// PUT /api/hardware/events/{id} - 更新事件状态/信息
 export async function PUT(request: NextRequest, { params }: { params: { id: string } }) {
   try {
+    let parsedBody: unknown
+
+    try {
+      parsedBody = await request.json()
+    } catch {
+      return NextResponse.json({ error: "请求体必须为JSON格式" }, { status: 400 })
+    }
+
+    if (!parsedBody || typeof parsedBody !== "object" || Array.isArray(parsedBody)) {
+      return NextResponse.json({ error: "请求体格式不正确" }, { status: 400 })
+    }
+
+    const body = parsedBody as EventUpdatePayload
+
+    if (
+      body.status === undefined &&
+      body.confidence_score === undefined &&
+      body.image_url === undefined &&
+      body.video_url === undefined &&
+      body.metadata === undefined &&
+      body.resolved_at === undefined &&
+      body.coordinates === undefined
+    ) {
+      return NextResponse.json({ error: "请提供需要更新的字段" }, { status: 400 })
+    }
+
     const supabase = await createClient()
-    const { id } = params
-    const body = await request.json()
 
-    const { status, metadata } = body
+    const { data: existingEvent, error: fetchError } = await supabase
+      .from("waste_events")
+      .select("metadata, resolved_at")
+      .eq("id", params.id)
+      .single()
 
-    const updateData: any = {
+    if (fetchError) {
+      if (fetchError.code === "PGRST116") {
+        return NextResponse.json({ error: "未找到事件" }, { status: 404 })
+      }
+
+      console.error("查询事件失败:", fetchError)
+      return NextResponse.json({ error: "查询事件失败" }, { status: 500 })
+    }
+
+    const updates: Record<string, unknown> = {
       updated_at: new Date().toISOString(),
     }
 
-    if (status) {
-      updateData.status = status
-      if (status === "resolved") {
-        updateData.resolved_at = new Date().toISOString()
+    if (body.status) {
+      if (!EVENT_STATUSES.includes(body.status)) {
+        return NextResponse.json({ error: "事件状态无效" }, { status: 400 })
+      }
+
+      updates.status = body.status
+
+      if (body.status === "resolved" && body.resolved_at === undefined) {
+        updates.resolved_at = new Date().toISOString()
       }
     }
 
-    if (metadata) {
-      updateData.metadata = metadata
+    if (body.resolved_at !== undefined) {
+      if (body.resolved_at === null) {
+        updates.resolved_at = null
+      } else {
+        const resolvedAt = Date.parse(body.resolved_at)
+        if (Number.isNaN(resolvedAt)) {
+          return NextResponse.json({ error: "resolved_at 时间格式无效" }, { status: 400 })
+        }
+        updates.resolved_at = new Date(resolvedAt).toISOString()
+      }
     }
 
-    const { data: event, error } = await supabase.from("waste_events").update(updateData).eq("id", id).select().single()
+    if (body.confidence_score !== undefined) {
+      if (typeof body.confidence_score !== "number" || body.confidence_score < 0 || body.confidence_score > 1) {
+        return NextResponse.json({ error: "confidence_score 必须在 0 和 1 之间" }, { status: 400 })
+      }
+      updates.confidence_score = body.confidence_score
+    }
 
-    if (error) {
+    if (body.image_url !== undefined) {
+      if (body.image_url !== null && typeof body.image_url !== "string") {
+        return NextResponse.json({ error: "image_url 必须为字符串或 null" }, { status: 400 })
+      }
+      updates.image_url = body.image_url
+    }
+
+    if (body.video_url !== undefined) {
+      if (body.video_url !== null && typeof body.video_url !== "string") {
+        return NextResponse.json({ error: "video_url 必须为字符串或 null" }, { status: 400 })
+      }
+      updates.video_url = body.video_url
+    }
+
+    if (body.coordinates !== undefined) {
+      if (body.coordinates === null) {
+        updates.coordinates = null
+      } else if (!isCoordinates(body.coordinates)) {
+        return NextResponse.json({ error: "coordinates 格式无效" }, { status: 400 })
+      } else {
+        updates.coordinates = body.coordinates
+      }
+    }
+
+    if (body.metadata !== undefined) {
+      if (body.metadata === null) {
+        updates.metadata = null
+      } else if (!isRecord(body.metadata)) {
+        return NextResponse.json({ error: "metadata 必须为对象" }, { status: 400 })
+      } else {
+        const baseMetadata = isRecord(existingEvent?.metadata)
+          ? (existingEvent!.metadata as Record<string, unknown>)
+          : {}
+        updates.metadata = {
+          ...baseMetadata,
+          ...body.metadata,
+        }
+      }
+    }
+
+    if (Object.keys(updates).length === 1) {
+      return NextResponse.json({ error: "没有可更新的字段" }, { status: 400 })
+    }
+
+    const { data: event, error: updateError } = await supabase
+      .from("waste_events")
+      .update(updates)
+      .eq("id", params.id)
+      .select(EVENT_SELECT)
+      .single()
+
+    if (updateError) {
+      console.error("更新事件失败:", updateError)
       return NextResponse.json({ error: "更新事件失败" }, { status: 500 })
     }
 
     return NextResponse.json({
       success: true,
-      message: "事件更新成功",
+      message: "事件已更新",
       data: event,
     })
   } catch (error) {

--- a/app/api/hardware/events/route.ts
+++ b/app/api/hardware/events/route.ts
@@ -1,6 +1,8 @@
 import { createClient } from "@/lib/supabase/server"
 import { type NextRequest, NextResponse } from "next/server"
 
+export const dynamic = "force-dynamic"
+
 // POST /api/hardware/events - 硬件设备上报废物倾倒事件
 export async function POST(request: NextRequest) {
   try {

--- a/app/api/hardware/locations/[id]/ping/route.ts
+++ b/app/api/hardware/locations/[id]/ping/route.ts
@@ -1,52 +1,120 @@
 import { createClient } from "@/lib/supabase/server"
 import { type NextRequest, NextResponse } from "next/server"
 
-// POST /api/hardware/locations/[id]/ping - 设备心跳检测
+export const dynamic = "force-dynamic"
+
+const CAMERA_STATUSES = ["active", "inactive", "maintenance"] as const
+
+type CameraStatus = (typeof CAMERA_STATUSES)[number]
+
+type HeartbeatPayload = {
+  camera_status?: CameraStatus
+  settings?: Record<string, unknown>
+  metadata?: Record<string, unknown>
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value)
+}
+
+// POST /api/hardware/locations/{id}/ping - 设备心跳
 export async function POST(request: NextRequest, { params }: { params: { id: string } }) {
   try {
+    let parsedBody: unknown = {}
+
+    if (request.headers.get("content-length") !== "0") {
+      try {
+        parsedBody = await request.json()
+      } catch {
+        return NextResponse.json({ error: "请求体必须为JSON格式" }, { status: 400 })
+      }
+    }
+
+    if (parsedBody && typeof parsedBody !== "object") {
+      return NextResponse.json({ error: "请求体格式不正确" }, { status: 400 })
+    }
+
+    const body = (parsedBody ?? {}) as HeartbeatPayload
     const supabase = await createClient()
-    const { id } = params
-    const body = await request.json()
 
-    const { camera_status = "active", settings, metadata } = body
+    const { data: location, error: fetchError } = await supabase
+      .from("monitoring_locations")
+      .select("settings")
+      .eq("id", params.id)
+      .single()
 
-    const updateData: any = {
+    if (fetchError) {
+      if (fetchError.code === "PGRST116") {
+        return NextResponse.json({ error: "未找到监控点" }, { status: 404 })
+      }
+
+      console.error("查询监控点失败:", fetchError)
+      return NextResponse.json({ error: "查询监控点失败" }, { status: 500 })
+    }
+
+    const updates: Record<string, unknown> = {
       last_ping: new Date().toISOString(),
-      camera_status,
       updated_at: new Date().toISOString(),
     }
 
-    if (settings) {
-      updateData.settings = settings
+    if (body.camera_status) {
+      if (!CAMERA_STATUSES.includes(body.camera_status)) {
+        return NextResponse.json({ error: "camera_status 无效" }, { status: 400 })
+      }
+      updates.camera_status = body.camera_status
     }
 
-    const { data: location, error } = await supabase
+    let settingsChanged = false
+    const baseSettings = isRecord(location?.settings) ? { ...location!.settings } : {}
+
+    if (body.settings) {
+      if (!isRecord(body.settings)) {
+        return NextResponse.json({ error: "settings 必须为对象" }, { status: 400 })
+      }
+      Object.assign(baseSettings, body.settings)
+      settingsChanged = true
+    }
+
+    if (body.metadata) {
+      if (!isRecord(body.metadata)) {
+        return NextResponse.json({ error: "metadata 必须为对象" }, { status: 400 })
+      }
+      const telemetryBase = isRecord((baseSettings as Record<string, unknown>).telemetry)
+        ? ((baseSettings as Record<string, unknown>).telemetry as Record<string, unknown>)
+        : {}
+      const telemetry: Record<string, unknown> = {
+        ...telemetryBase,
+        ...body.metadata,
+        last_heartbeat_at: updates.last_ping,
+      }
+      const deviceId = request.headers.get("x-device-id")
+      if (deviceId) {
+        telemetry.device_id = deviceId
+      }
+      ;(baseSettings as Record<string, unknown>).telemetry = telemetry
+      settingsChanged = true
+    }
+
+    if (settingsChanged) {
+      updates.settings = baseSettings
+    }
+
+    const { data: updatedLocation, error: updateError } = await supabase
       .from("monitoring_locations")
-      .update(updateData)
-      .eq("id", id)
-      .select()
+      .update(updates)
+      .eq("id", params.id)
+      .select("*")
       .single()
 
-    if (error || !location) {
-      return NextResponse.json({ error: "监控点不存在或更新失败" }, { status: 404 })
+    if (updateError) {
+      console.error("更新监控点失败:", updateError)
+      return NextResponse.json({ error: "更新监控点失败" }, { status: 500 })
     }
-
-    // 检查是否有待处理的事件需要设备处理
-    const { data: pendingEvents } = await supabase
-      .from("waste_events")
-      .select("id, event_type, status")
-      .eq("location_id", id)
-      .eq("status", "pending")
-      .limit(10)
 
     return NextResponse.json({
       success: true,
-      message: "心跳更新成功",
-      data: {
-        location,
-        pending_events: pendingEvents || [],
-        server_time: new Date().toISOString(),
-      },
+      message: "已接收设备心跳",
+      data: updatedLocation,
     })
   } catch (error) {
     console.error("API错误:", error)

--- a/app/api/hardware/locations/[id]/route.ts
+++ b/app/api/hardware/locations/[id]/route.ts
@@ -1,0 +1,174 @@
+import { createClient } from "@/lib/supabase/server"
+import { type NextRequest, NextResponse } from "next/server"
+
+export const dynamic = "force-dynamic"
+
+const CAMERA_STATUSES = ["active", "inactive", "maintenance"] as const
+
+type CameraStatus = (typeof CAMERA_STATUSES)[number]
+
+type Coordinates = {
+  lat: number
+  lng: number
+}
+
+type LocationUpdatePayload = {
+  name?: string
+  address?: string
+  coordinates?: Coordinates | null
+  camera_status?: CameraStatus
+  settings?: Record<string, unknown>
+}
+
+function isCoordinates(value: unknown): value is Coordinates {
+  if (!value || typeof value !== "object") {
+    return false
+  }
+
+  const { lat, lng } = value as { lat?: unknown; lng?: unknown }
+  return typeof lat === "number" && typeof lng === "number"
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value)
+}
+
+// GET /api/hardware/locations/{id} - 获取监控点详情
+export async function GET(_request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const supabase = await createClient()
+
+    const { data: location, error } = await supabase
+      .from("monitoring_locations")
+      .select("*")
+      .eq("id", params.id)
+      .single()
+
+    if (error) {
+      if (error.code === "PGRST116") {
+        return NextResponse.json({ error: "未找到监控点" }, { status: 404 })
+      }
+
+      console.error("查询监控点失败:", error)
+      return NextResponse.json({ error: "查询监控点失败" }, { status: 500 })
+    }
+
+    return NextResponse.json({
+      success: true,
+      data: location,
+    })
+  } catch (error) {
+    console.error("API错误:", error)
+    return NextResponse.json({ error: "服务器内部错误" }, { status: 500 })
+  }
+}
+
+// PATCH /api/hardware/locations/{id} - 更新监控点信息
+export async function PATCH(request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    let parsedBody: unknown
+
+    try {
+      parsedBody = await request.json()
+    } catch {
+      return NextResponse.json({ error: "请求体必须为JSON格式" }, { status: 400 })
+    }
+
+    if (!parsedBody || typeof parsedBody !== "object" || Array.isArray(parsedBody)) {
+      return NextResponse.json({ error: "请求体格式不正确" }, { status: 400 })
+    }
+
+    const body = parsedBody as LocationUpdatePayload
+
+    if (
+      body.name === undefined &&
+      body.address === undefined &&
+      body.coordinates === undefined &&
+      body.camera_status === undefined &&
+      body.settings === undefined
+    ) {
+      return NextResponse.json({ error: "请提供需要更新的字段" }, { status: 400 })
+    }
+
+    const supabase = await createClient()
+
+    const { data: existingLocation, error: fetchError } = await supabase
+      .from("monitoring_locations")
+      .select("settings")
+      .eq("id", params.id)
+      .single()
+
+    if (fetchError) {
+      if (fetchError.code === "PGRST116") {
+        return NextResponse.json({ error: "未找到监控点" }, { status: 404 })
+      }
+
+      console.error("查询监控点失败:", fetchError)
+      return NextResponse.json({ error: "查询监控点失败" }, { status: 500 })
+    }
+
+    const updates: Record<string, unknown> = {
+      updated_at: new Date().toISOString(),
+    }
+
+    if (body.name !== undefined) {
+      updates.name = body.name
+    }
+
+    if (body.address !== undefined) {
+      updates.address = body.address
+    }
+
+    if (body.coordinates !== undefined) {
+      if (body.coordinates === null) {
+        updates.coordinates = null
+      } else if (!isCoordinates(body.coordinates)) {
+        return NextResponse.json({ error: "coordinates 格式无效" }, { status: 400 })
+      } else {
+        updates.coordinates = body.coordinates
+      }
+    }
+
+    if (body.camera_status) {
+      if (!CAMERA_STATUSES.includes(body.camera_status)) {
+        return NextResponse.json({ error: "camera_status 无效" }, { status: 400 })
+      }
+      updates.camera_status = body.camera_status
+    }
+
+    if (body.settings) {
+      if (!isRecord(body.settings)) {
+        return NextResponse.json({ error: "settings 必须为对象" }, { status: 400 })
+      }
+      const mergedSettings = isRecord(existingLocation?.settings)
+        ? { ...(existingLocation!.settings as Record<string, unknown>), ...body.settings }
+        : { ...body.settings }
+      updates.settings = mergedSettings
+    }
+
+    if (Object.keys(updates).length === 1) {
+      return NextResponse.json({ error: "没有可更新的字段" }, { status: 400 })
+    }
+
+    const { data: location, error: updateError } = await supabase
+      .from("monitoring_locations")
+      .update(updates)
+      .eq("id", params.id)
+      .select("*")
+      .single()
+
+    if (updateError) {
+      console.error("更新监控点失败:", updateError)
+      return NextResponse.json({ error: "更新监控点失败" }, { status: 500 })
+    }
+
+    return NextResponse.json({
+      success: true,
+      message: "监控点已更新",
+      data: location,
+    })
+  } catch (error) {
+    console.error("API错误:", error)
+    return NextResponse.json({ error: "服务器内部错误" }, { status: 500 })
+  }
+}

--- a/app/api/hardware/locations/route.ts
+++ b/app/api/hardware/locations/route.ts
@@ -1,6 +1,8 @@
 import { createClient } from "@/lib/supabase/server"
 import { type NextRequest, NextResponse } from "next/server"
 
+export const dynamic = "force-dynamic"
+
 // GET /api/hardware/locations - 获取监控点列表
 export async function GET(request: NextRequest) {
   try {

--- a/docs/hardware-api.md
+++ b/docs/hardware-api.md
@@ -50,7 +50,7 @@ POST /api/hardware/events
 
 #### 查询事件列表
 \`\`\`http
-GET /api/hardware/events?location_id=KS001&status=pending&limit=50&offset=0
+GET /api/hardware/events?location_id=KS001&status=active&limit=50&offset=0
 \`\`\`
 
 #### 获取事件详情
@@ -58,9 +58,22 @@ GET /api/hardware/events?location_id=KS001&status=pending&limit=50&offset=0
 GET /api/hardware/events/{event_id}
 \`\`\`
 
-#### 更新事件状态
+#### 更新事件状态/信息
 \`\`\`http
 PUT /api/hardware/events/{event_id}
+\`\`\`
+
+**请求体（按需传入字段）**:
+\`\`\`json
+{
+  "status": "resolved",
+  "resolved_at": "2024-05-06T10:30:00Z",
+  "metadata": {
+    "reviewed_by": "operator-01",
+    "notes": "现场处理完毕"
+  },
+  "confidence_score": 0.92
+}
 \`\`\`
 
 ### 2. 监控点管理
@@ -93,6 +106,27 @@ POST /api/hardware/locations
 GET /api/hardware/locations?active_only=true
 \`\`\`
 
+#### 获取监控点详情
+\`\`\`http
+GET /api/hardware/locations/{location_id}
+\`\`\`
+
+#### 更新监控点设置
+\`\`\`http
+PATCH /api/hardware/locations/{location_id}
+\`\`\`
+
+**请求体（示例）**:
+\`\`\`json
+{
+  "camera_status": "maintenance",
+  "settings": {
+    "detection_sensitivity": 0.75,
+    "voice_enabled": false
+  }
+}
+\`\`\`
+
 #### 设备心跳检测
 \`\`\`http
 POST /api/hardware/locations/{location_id}/ping
@@ -117,12 +151,27 @@ POST /api/hardware/locations/{location_id}/ping
 
 #### 获取警报列表
 \`\`\`http
-GET /api/hardware/alerts?location_id=KS001&status=active&limit=20
+GET /api/hardware/alerts?location_id=KS001&status=sent&limit=20
 \`\`\`
 
-#### 确认警报
+#### 获取警报详情
 \`\`\`http
-PUT /api/hardware/alerts/{alert_id}/acknowledge
+GET /api/hardware/alerts/{alert_id}
+\`\`\`
+
+#### 更新/确认警报
+\`\`\`http
+PATCH /api/hardware/alerts/{alert_id}
+\`\`\`
+
+**请求体（示例）**:
+\`\`\`json
+{
+  "status": "acknowledged",
+  "metadata": {
+    "acknowledged_by": "edge-device-01"
+  }
+}
 \`\`\`
 
 ## 事件类型
@@ -132,12 +181,10 @@ PUT /api/hardware/alerts/{alert_id}/acknowledge
 - `suspicious_activity`: 可疑活动
 - `maintenance_needed`: 需要维护
 
-## 状态码
+## 状态字段
 
-- `pending`: 待处理
-- `processing`: 处理中
-- `resolved`: 已解决
-- `dismissed`: 已忽略
+- **废物事件 `status`**: `active`, `investigating`, `resolved`, `false_positive`
+- **警报 `status`**: `pending`, `sent`, `failed`, `acknowledged`
 
 ## 错误处理
 

--- a/scripts/001_create_waste_events_table.sql
+++ b/scripts/001_create_waste_events_table.sql
@@ -42,7 +42,7 @@ CREATE TABLE IF NOT EXISTS alerts (
   alert_type TEXT NOT NULL CHECK (alert_type IN ('voice_warning', 'light_flash', 'sms', 'email', 'dashboard')),
   message TEXT NOT NULL,
   sent_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-  status TEXT NOT NULL DEFAULT 'sent' CHECK (status IN ('pending', 'sent', 'failed')),
+  status TEXT NOT NULL DEFAULT 'sent' CHECK (status IN ('pending', 'sent', 'failed', 'acknowledged')),
   metadata JSONB
 );
 


### PR DESCRIPTION
## Summary
- add granular RESTful alert, event, and location routes for hardware integrations
- extend the hardware documentation and schema to cover acknowledgement flows and telemetry updates
- ensure all hardware API handlers opt into dynamic rendering for Supabase cookie usage

## Testing
- pnpm build
- pnpm lint *(fails: prompts for interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68ce8b8c99b4832798e9893426fc6dca